### PR TITLE
GitHub Actions pnpmインストール問題を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
           ${{ runner.os }}-pnpm-store-
           
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: pnpm install
       
     - name: Build
       run: pnpm build


### PR DESCRIPTION
- --frozen-lockfileオプションを削除
- より柔軟な依存関係解決を許可
- GitHub Actions環境での互換性を向上