### PR TITLE
fix(ci): pnpmのバージョン競合を解決

### DIFF
--- a/.github/workflows/deploy-advanced.yml
+++ b/.github/workflows/deploy-advanced.yml
@@ -31,8 +31,6 @@ jobs:
 
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
-      with:
-        version: 8
 
     - name: Setup Node.js
       uses: actions/setup-node@v4


### PR DESCRIPTION
pnpm/action-setupでバージョンをハードコーディングしていたため、package.jsonのpackageManagerで指定されたバージョンと競合が発生していた問題を修正しました。

ワークフローからバージョン指定を削除し、package.jsonから自動的にバージョンを検出するようにしました。これにより、ローカル環境とCI環境でのpnpmのバージョンが一致し、一貫性が保たれます。