### PR TITLE
feat: Add resizable input and output nodes with optimized node sizes

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -29,18 +29,18 @@ const NodePropertiesPanel = ({ editingNode, onEditingNodeChange }) => {
   };
 
   return (
-    <div className="p-4 border-t">
-      <h3 className="font-semibold mb-4 text-sm">ノードプロパティ</h3>
-      <div className="space-y-4">
-        <div><label className="block text-sm font-medium mb-1">ノード名</label><input type="text" value={editingNode.data.label} onChange={(e) => handleDataChange({ label: e.target.value })} className="w-full px-3 py-2 border rounded-md" /></div>
+    <div className="p-3">
+      <h3 className="font-semibold mb-3 text-sm text-gray-700">ノードプロパティ</h3>
+      <div className="space-y-2">
+        <div><label className="block text-xs font-medium mb-1 text-gray-600">ノード名</label><input type="text" value={editingNode.data.label} onChange={(e) => handleDataChange({ label: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md" /></div>
         {editingNode.type === 'input' && (
           <>
             <div>
-              <label className="block text-sm font-medium mb-1">入力タイプ</label>
+              <label className="block text-xs font-medium mb-1 text-gray-600">入力タイプ</label>
               <select
                 value={editingNode.data.inputType || 'text'}
                 onChange={(e) => handleDataChange({ inputType: e.target.value, value: '', fileContent: null, fileName: null })}
-                className="w-full px-3 py-2 border rounded-md"
+                className="w-full px-2 py-1.5 text-sm border rounded-md"
               >
                 <option value="text">テキスト</option>
                 <option value="file">ファイル (txt)</option>
@@ -48,17 +48,17 @@ const NodePropertiesPanel = ({ editingNode, onEditingNodeChange }) => {
             </div>
             {(editingNode.data.inputType === 'file') ? (
               <div>
-                <label className="block text-sm font-medium mb-1">入力ファイル</label>
+                <label className="block text-xs font-medium mb-1 text-gray-600">入力ファイル</label>
                 <input type="file" accept=".txt" onChange={handleFileChange} className="w-full text-sm file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-violet-50 file:text-violet-700 hover:file:bg-violet-100" />
                 {editingNode.data.fileName && <p className="text-xs text-gray-500 mt-1">読み込み済み: {editingNode.data.fileName}</p>}
               </div>
             ) : (
               <div>
-                <label className="block text-sm font-medium mb-1">入力値</label>
+                <label className="block text-xs font-medium mb-1 text-gray-600">入力値</label>
                 <textarea
                   value={editingNode.data.value || ''}
                   onChange={(e) => handleDataChange({ value: e.target.value })}
-                  className="w-full px-3 py-2 border rounded-md"
+                  className="w-full px-2 py-1.5 text-sm border rounded-md"
                   rows={3}
                   placeholder="実行時の入力値を設定します"
                 />
@@ -68,14 +68,14 @@ const NodePropertiesPanel = ({ editingNode, onEditingNodeChange }) => {
         )}
         {editingNode.type === 'llm' && (
           <>
-            <div><label className="block text-sm font-medium mb-1">プロンプト</label><textarea value={editingNode.data.prompt || ''} onChange={(e) => handleDataChange({ prompt: e.target.value })} className="w-full px-3 py-2 border rounded-md" rows={5} placeholder="プロンプトを入力してください" /></div>
-            <div><label className="block text-sm font-medium mb-1">Temperature</label><input type="number" value={editingNode.data.temperature || 0.7} onChange={(e) => handleDataChange({ temperature: parseFloat(e.target.value) })} className="w-full px-3 py-2 border rounded-md" min="0" max="2" step="0.1" /></div>
-            <div><label className="block text-sm font-medium mb-1">Model</label><select value={editingNode.data.model || 'gpt-5-nano'} onChange={(e) => handleDataChange({ model: e.target.value })} className="w-full px-3 py-2 border rounded-md"><option value="gpt-5">gpt-5</option><option value="gpt-5-mini">gpt-5-mini</option><option value="gpt-5-nano">gpt-5-nano</option></select></div>
+            <div><label className="block text-xs font-medium mb-1 text-gray-600">プロンプト</label><textarea value={editingNode.data.prompt || ''} onChange={(e) => handleDataChange({ prompt: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md" rows={5} placeholder="プロンプトを入力してください" /></div>
+            <div><label className="block text-xs font-medium mb-1 text-gray-600">Temperature</label><input type="number" value={editingNode.data.temperature || 0.7} onChange={(e) => handleDataChange({ temperature: parseFloat(e.target.value) })} className="w-full px-2 py-1.5 text-sm border rounded-md" min="0" max="2" step="0.1" /></div>
+            <div><label className="block text-xs font-medium mb-1 text-gray-600">Model</label><select value={editingNode.data.model || 'gpt-5-nano'} onChange={(e) => handleDataChange({ model: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md"><option value="gpt-5">gpt-5</option><option value="gpt-5-mini">gpt-5-mini</option><option value="gpt-5-nano">gpt-5-nano</option></select></div>
           </>
         )}
-        {editingNode.type === 'if' && ( <><div><label className="block text-sm font-medium mb-1">条件タイプ</label><select value={editingNode.data.conditionType || 'llm'} onChange={(e) => handleDataChange({ conditionType: e.target.value })} className="w-full px-3 py-2 border rounded-md"><option value="llm">LLM判断</option><option value="variable">変数比較</option></select></div>{editingNode.data.conditionType === 'llm' ? (<><div><label className="block text-sm font-medium mb-1">判断条件</label><textarea value={editingNode.data.condition || ''} onChange={(e) => handleDataChange({ condition: e.target.value })} className="w-full px-3 py-2 border rounded-md" rows={3} placeholder="LLMに判断させる条件を入力" /></div><div><label className="block text-sm font-medium mb-1">Temperature</label><input type="number" value={editingNode.data.temperature || 0.7} onChange={(e) => handleDataChange({ temperature: parseFloat(e.target.value) })} className="w-full px-3 py-2 border rounded-md" min="0" max="2" step="0.1" /></div><div><label className="block text-sm font-medium mb-1">Model</label><select value={editingNode.data.model || 'gpt-5-nano'} onChange={(e) => handleDataChange({ model: e.target.value })} className="w-full px-3 py-2 border rounded-md"><option value="gpt-5">gpt-5</option><option value="gpt-5-mini">gpt-5-mini</option><option value="gpt-5-nano">gpt-5-nano</option></select></div></>) : (<><div><label className="block text-sm font-medium mb-1">変数名</label><input type="text" value={editingNode.data.variable || ''} onChange={(e) => handleDataChange({ variable: e.target.value })} className="w-full px-3 py-2 border rounded-md" placeholder="比較する変数名" /></div><div><label className="block text-sm font-medium mb-1">演算子</label><select value={editingNode.data.operator || '=='} onChange={(e) => handleDataChange({ operator: e.target.value })} className="w-full px-3 py-2 border rounded-md"><option value="==">==(等しい)</option><option value="!=">!=(等しくない)</option><option value="<">&lt;(より小さい)</option><option value="<=">&lt;=(以下)</option><option value=">">&gt;(より大きい)</option><option value=">=">&gt;=(以上)</option></select></div><div><label className="block text-sm font-medium mb-1">比較値</label><input type="text" value={editingNode.data.value || ''} onChange={(e) => handleDataChange({ value: e.target.value })} className="w-full px-3 py-2 border rounded-md" placeholder="比較する値" /></div></>)}</> )}
-        {editingNode.type === 'while' && ( <><div><label className="block text-sm font-medium mb-1">条件タイプ</label><select value={editingNode.data.conditionType || 'variable'} onChange={(e) => handleDataChange({ conditionType: e.target.value })} className="w-full px-3 py-2 border rounded-md"><option value="variable">変数比較</option><option value="llm">LLM判断</option></select></div>{editingNode.data.conditionType === 'variable' ? (<><div><label className="block text-sm font-medium mb-1">変数名</label><input type="text" value={editingNode.data.variable || ''} onChange={(e) => handleDataChange({ variable: e.target.value })} className="w-full px-3 py-2 border rounded-md" placeholder="比較する変数名" /></div><div><label className="block text-sm font-medium mb-1">演算子</label><select value={editingNode.data.operator || '<'} onChange={(e) => handleDataChange({ operator: e.target.value })} className="w-full px-3 py-2 border rounded-md"><option value="==">==(等しい)</option><option value="!=">!=(等しくない)</option><option value="<">&lt;(より小さい)</option><option value="<=">&lt;=(以下)</option><option value=">">&gt;(より大きい)</option><option value=">=">&gt;=(以上)</option></select></div><div><label className="block text-sm font-medium mb-1">比較値</label><input type="text" value={editingNode.data.value || ''} onChange={(e) => handleDataChange({ value: e.target.value })} className="w-full px-3 py-2 border rounded-md" placeholder="比較する値" /></div></>) : (<div><label className="block text-sm font-medium mb-1">継続条件</label><textarea value={editingNode.data.condition || ''} onChange={(e) => handleDataChange({ condition: e.target.value })} className="w-full px-3 py-2 border rounded-md" rows={3} placeholder="繰り返しを継続する条件を入力" /></div>)}<div><label className="block text-sm font-medium mb-1">最大繰り返し回数</label><input type="number" value={editingNode.data.maxIterations || 100} onChange={(e) => handleDataChange({ maxIterations: parseInt(e.target.value) })} className="w-full px-3 py-2 border rounded-md" min="1" max="1000" /></div></> )}
-        {editingNode.type === 'output' && ( <><div><label className="block text-sm font-medium mb-1">出力形式</label><select value={editingNode.data.format || 'text'} onChange={(e) => handleDataChange({ format: e.target.value })} className="w-full px-3 py-2 border rounded-md"><option value="text">テキスト</option><option value="json">JSON</option><option value="markdown">Markdown</option></select></div><div><label className="block text-sm font-medium mb-1">実行結果</label><textarea value={String(editingNode.data.result || '')} readOnly className="w-full px-3 py-2 border rounded-md bg-gray-100" rows={5} /></div></> )}
+        {editingNode.type === 'if' && ( <><div><label className="block text-xs font-medium mb-1 text-gray-600">条件タイプ</label><select value={editingNode.data.conditionType || 'llm'} onChange={(e) => handleDataChange({ conditionType: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md"><option value="llm">LLM判断</option><option value="variable">変数比較</option></select></div>{editingNode.data.conditionType === 'llm' ? (<><div><label className="block text-xs font-medium mb-1 text-gray-600">判断条件</label><textarea value={editingNode.data.condition || ''} onChange={(e) => handleDataChange({ condition: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md" rows={3} placeholder="LLMに判断させる条件を入力" /></div><div><label className="block text-xs font-medium mb-1 text-gray-600">Temperature</label><input type="number" value={editingNode.data.temperature || 0.7} onChange={(e) => handleDataChange({ temperature: parseFloat(e.target.value) })} className="w-full px-2 py-1.5 text-sm border rounded-md" min="0" max="2" step="0.1" /></div><div><label className="block text-xs font-medium mb-1 text-gray-600">Model</label><select value={editingNode.data.model || 'gpt-5-nano'} onChange={(e) => handleDataChange({ model: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md"><option value="gpt-5">gpt-5</option><option value="gpt-5-mini">gpt-5-mini</option><option value="gpt-5-nano">gpt-5-nano</option></select></div></>) : (<><div><label className="block text-xs font-medium mb-1 text-gray-600">変数名</label><input type="text" value={editingNode.data.variable || ''} onChange={(e) => handleDataChange({ variable: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md" placeholder="比較する変数名" /></div><div><label className="block text-xs font-medium mb-1 text-gray-600">演算子</label><select value={editingNode.data.operator || '=='} onChange={(e) => handleDataChange({ operator: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md"><option value="==">==(等しい)</option><option value="!=">!=(等しくない)</option><option value="<">&lt;(より小さい)</option><option value="<=">&lt;=(以下)</option><option value=">">&gt;(より大きい)</option><option value=">=">&gt;=(以上)</option></select></div><div><label className="block text-xs font-medium mb-1 text-gray-600">比較値</label><input type="text" value={editingNode.data.value || ''} onChange={(e) => handleDataChange({ value: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md" placeholder="比較する値" /></div></>)}</> )}
+        {editingNode.type === 'while' && ( <><div><label className="block text-xs font-medium mb-1 text-gray-600">条件タイプ</label><select value={editingNode.data.conditionType || 'variable'} onChange={(e) => handleDataChange({ conditionType: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md"><option value="variable">変数比較</option><option value="llm">LLM判断</option></select></div>{editingNode.data.conditionType === 'variable' ? (<><div><label className="block text-xs font-medium mb-1 text-gray-600">変数名</label><input type="text" value={editingNode.data.variable || ''} onChange={(e) => handleDataChange({ variable: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md" placeholder="比較する変数名" /></div><div><label className="block text-xs font-medium mb-1 text-gray-600">演算子</label><select value={editingNode.data.operator || '<'} onChange={(e) => handleDataChange({ operator: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md"><option value="==">==(等しい)</option><option value="!=">!=(等しくない)</option><option value="<">&lt;(より小さい)</option><option value="<=">&lt;=(以下)</option><option value=">">&gt;(より大きい)</option><option value=">=">&gt;=(以上)</option></select></div><div><label className="block text-xs font-medium mb-1 text-gray-600">比較値</label><input type="text" value={editingNode.data.value || ''} onChange={(e) => handleDataChange({ value: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md" placeholder="比較する値" /></div></>) : (<div><label className="block text-xs font-medium mb-1 text-gray-600">継続条件</label><textarea value={editingNode.data.condition || ''} onChange={(e) => handleDataChange({ condition: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md" rows={3} placeholder="繰り返しを継続する条件を入力" /></div>)}<div><label className="block text-xs font-medium mb-1 text-gray-600">最大繰り返し回数</label><input type="number" value={editingNode.data.maxIterations || 100} onChange={(e) => handleDataChange({ maxIterations: parseInt(e.target.value) })} className="w-full px-2 py-1.5 text-sm border rounded-md" min="1" max="1000" /></div></> )}
+        {editingNode.type === 'output' && ( <><div><label className="block text-xs font-medium mb-1 text-gray-600">出力形式</label><select value={editingNode.data.format || 'text'} onChange={(e) => handleDataChange({ format: e.target.value })} className="w-full px-2 py-1.5 text-sm border rounded-md"><option value="text">テキスト</option><option value="json">JSON</option><option value="markdown">Markdown</option></select></div><div><label className="block text-xs font-medium mb-1 text-gray-600">実行結果</label><textarea value={String(editingNode.data.result || '')} readOnly className="w-full px-3 py-2 border rounded-md bg-gray-100" rows={5} /></div></> )}
       </div>
     </div>
   )
@@ -102,11 +102,11 @@ const Layout = ({ children, currentView, onViewChange, editingNode, onEditingNod
           </div>
         </div>
         
-        <nav className="flex-1 p-4 overflow-y-auto">
-          <ul className="space-y-2">
+        <nav className="flex-shrink-0 p-3">
+          <ul className="space-y-1">
             {menuItems.map((item) => (
               <li key={item.id}>
-                <Button variant={currentView === item.id ? 'default' : 'ghost'} className="w-full justify-start" onClick={() => onViewChange(item.id)}>
+                <Button variant={currentView === item.id ? 'default' : 'ghost'} size="sm" className="w-full justify-start h-8" onClick={() => onViewChange(item.id)}>
                   <item.icon className="h-4 w-4 mr-2" />
                   {item.label}
                 </Button>
@@ -116,7 +116,7 @@ const Layout = ({ children, currentView, onViewChange, editingNode, onEditingNod
         </nav>
 
         {currentView === 'workflow' && (
-          <div className="flex-shrink-0 overflow-y-auto">
+          <div className="flex-1 overflow-y-auto border-t">
             <NodePropertiesPanel editingNode={editingNode} onEditingNodeChange={onEditingNodeChange} />
           </div>
         )}

--- a/src/services/nodeExecutionService.js
+++ b/src/services/nodeExecutionService.js
@@ -20,9 +20,15 @@ class NodeExecutionService {
       level,
       message,
       nodeId,
-      data,
-      variables: { ...this.variables }
+      data: this.debugMode ? data : null, // デバッグ時のみデータ保存
+      variables: this.debugMode ? { ...this.variables } : null // デバッグ時のみ変数コピー
     }
+    
+    // ログサイズ制限（最大500エントリー）
+    if (this.executionLog.length >= 500) {
+      this.executionLog = this.executionLog.slice(-400); // 古い100エントリーを削除
+    }
+    
     this.executionLog.push(logEntry)
     if (this.debugMode) {
       console.log(`[${level}] ${message}`, data)
@@ -35,6 +41,15 @@ class NodeExecutionService {
 
   clearLog() {
     this.executionLog = []
+  }
+
+  // メモリ使用量最適化のためのクリーンアップ
+  cleanup() {
+    this.executionContext = {}
+    this.variables = {}
+    this.clearLog()
+    this.isExecuting = false
+    this.executor = null
   }
 
   startExecution(nodes, connections, inputData = {}, nodeTypes = {}) {


### PR DESCRIPTION
## Summary
- 入力・出力ノードのリサイズ機能を実装
- ノードタイプ別に最適化されたデフォルトサイズを設定
- LLM生成ノードのプロンプト全体をテキストエリアで表示
- サイドバーUIの最適化とコンパクト化

## 主な変更内容

### リサイズ機能
- 入力・出力ノードに右下角のリサイズハンドルを追加
- マウスドラッグでウィンドウサイズを動的に変更可能
- テキストエリアの高さも連動して調整

### ノードサイズ最適化
- **入力・出力ノード**: 180x168px (高さ1.2倍)
- **LLM生成ノード**: 320x240px (幅・高さ2倍)
- **テキスト結合ノード**: 160x210px (高さ調整)
- **If条件分岐ノード**: 160x180px (高さ調整)
- **While繰り返しノード**: 160x220px (高さ調整)

### UI改善
- LLM生成ノードでプロンプト全体を表示するテキストエリア
- サイドバーの最適化とコンパクト化
- マウス操作時のテキスト選択防止
- 接続線の描画パフォーマンス向上

## Test plan
- [ ] 入力・出力ノードのリサイズ動作確認
- [ ] 各ノードタイプのデフォルトサイズ確認
- [ ] LLM生成ノードのプロンプト表示確認
- [ ] 既存機能の動作確認（ノード作成、接続、実行）
- [ ] パフォーマンスの改善確認

🤖 Generated with [Claude Code](https://claude.ai/code)